### PR TITLE
Refactor GenericTasks to prepare for separate structs for addressing by adding a dependency on a Tasks trait

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -371,7 +371,8 @@ impl<'a> CPU<'a> {
         addr_mode: AddressingMode,
         value_reader: Option<Box<dyn Fn(&mut CPU, Byte) -> ()>>,
     ) -> Box<dyn Tasks> {
-        let mut tasks = self.get_address(addr_mode);
+        let addr_tasks = self.get_address(addr_mode);
+        let mut tasks = GenericTasks::new_dependent(Box::new(addr_tasks));
 
         tasks.push(Rc::new(move |cpu: &mut CPU| {
             let value = cpu.access_memory(cpu.address_output);

--- a/src/cpu/instructions/inc_and_decrements.rs
+++ b/src/cpu/instructions/inc_and_decrements.rs
@@ -101,7 +101,8 @@ fn modify_memory(
     addr_mode: AddressingMode,
     cb: Box<dyn Fn(&u8) -> u8>,
 ) -> Box<dyn Tasks> {
-    let mut tasks = cpu.get_address(addr_mode);
+    let addr_tasks = cpu.get_address(addr_mode);
+    let mut tasks = GenericTasks::new_dependent(Box::new(addr_tasks));
 
     tasks.push(Rc::new(|cpu| {
         let value = cpu.access_memory(cpu.address_output);

--- a/src/cpu/instructions/jumps_and_calls.rs
+++ b/src/cpu/instructions/jumps_and_calls.rs
@@ -3,7 +3,8 @@ use std::rc::Rc;
 use crate::cpu::{tasks::GenericTasks, AddressingMode, TaskCycleVariant, Tasks, CPU};
 
 pub fn jsr_a(cpu: &mut CPU) -> Box<dyn Tasks> {
-    let mut tasks = cpu.get_address(AddressingMode::Absolute);
+    let addr_tasks = cpu.get_address(AddressingMode::Absolute);
+    let mut tasks = GenericTasks::new_dependent(Box::new(addr_tasks));
 
     tasks.push(Rc::new(|cpu: &mut CPU| {
         let [_, ret_program_counter_hi] = cpu.program_counter.clone().wrapping_sub(1).to_le_bytes();
@@ -65,7 +66,9 @@ pub fn rts(_cpu: &mut CPU) -> Box<dyn Tasks> {
 }
 
 fn jmp(cpu: &mut CPU, addr_mode: AddressingMode) -> Box<dyn Tasks> {
-    let mut tasks = cpu.get_address(addr_mode);
+    let addr_tasks = cpu.get_address(addr_mode);
+    let mut tasks = GenericTasks::new_dependent(Box::new(addr_tasks));
+
     tasks.push(Rc::new(|cpu| {
         cpu.program_counter = cpu.address_output;
 

--- a/src/cpu/instructions/load_and_store_ops.rs
+++ b/src/cpu/instructions/load_and_store_ops.rs
@@ -86,10 +86,8 @@ pub fn ldx_ay(cpu: &mut CPU) -> Box<dyn Tasks> {
 }
 
 pub fn store(cpu: &mut CPU, addr_mode: AddressingMode, register: Registers) -> Box<dyn Tasks> {
-    let mut tasks = GenericTasks::new();
-
-    let addr_cycles = cpu.get_address(addr_mode);
-    tasks.transfer_queue(addr_cycles);
+    let addr_tasks = cpu.get_address(addr_mode);
+    let mut tasks = GenericTasks::new_dependent(Box::new(addr_tasks));
 
     tasks.push(Rc::new(move |cpu| {
         let value = cpu.get_register(register);

--- a/src/cpu/instructions/shifts.rs
+++ b/src/cpu/instructions/shifts.rs
@@ -78,10 +78,8 @@ fn op_mem(
     op: Box<dyn Fn(bool) -> Box<dyn Fn(&u8) -> u8>>,
     dir: Directions,
 ) -> Box<dyn Tasks> {
-    let mut tasks = GenericTasks::new();
-
-    let addr_cycles = cpu.get_address(addr_mode);
-    tasks.transfer_queue(addr_cycles);
+    let addr_tasks = cpu.get_address(addr_mode);
+    let mut tasks = GenericTasks::new_dependent(Box::new(addr_tasks));
 
     tasks.push(Rc::new(|cpu| {
         let value = cpu.access_memory(cpu.address_output);


### PR DESCRIPTION
Prepare get_address to be implemented with dedicated struct by adding a dependency on `GenericTasks` which is ran before `tasks_queue`.